### PR TITLE
Implement timeTableSSC as an improvement to SCSimple

### DIFF
--- a/src/turbineModels/turbineModelsStandard/horizontalAxisWindTurbinesADM/controllers/superControllers/timeTableSSC.C
+++ b/src/turbineModels/turbineModelsStandard/horizontalAxisWindTurbinesADM/controllers/superControllers/timeTableSSC.C
@@ -1,0 +1,179 @@
+// _SSC_ 
+//  file: timeTableSSC.C
+//  by Paul Fleming & Bart Doekemeijer
+//  Date: 05/03/2018
+//
+//  Info: A superController code that loads a table and applies the control settings
+//        at the relevant timesteps.
+//
+//        this function will read an ascii text file defined by "char *inputFile",
+//        and apply the specified control settings at the specified time steps. This
+//        controller code is compatible with the "yawSC.H" and "PIDSC.H" turbine
+//        controller files, but can easily be extended or modified to one's needs.
+//
+
+#include <iostream>
+#include <vector>
+#include <stdio.h>
+#include <stdlib.h>
+
+// Read text file and format appropriately
+void readInputSSC(char *inputFile, int nTurbs, int nControlVars,
+				  std::vector<int> &nTurbInputs, std::vector< std::vector<float> >&timeArray, 
+				  std::vector< std::vector <std::vector<float> > > &controlArray)
+{
+	float controlTime; // Time at which the control action is applied
+	FILE *fp; 		   // Input file handle
+	char buffer[500];  // Define variables for handling SC_Struct
+	int turbID; 	   // Temporary turbine number
+	float temp;        // Temporary variable for scanning over floats in the input file
+	
+	// Define temporary (multi-dimensional) vectors
+	std::vector<float> tmpFloatVector; 					// Temporary float vector
+	std::vector< std::vector<float> > tmpFloatMatrix; 	// Temporary float matrix
+	std::vector<float> tmpControlVector(nControlVars, 0); // Temporary float vector 
+	
+	//Open file for reading
+	if((fp=fopen(inputFile, "r")) == NULL) {
+		fprintf(stderr,"%s: line %d: Cannot find SSC Input File with path '%s'.\n",__FILE__,__LINE__,inputFile);
+		exit(1);
+	}
+	else {
+		fprintf(stderr,"Successfully opened SSC Input File '%s'.\n",inputFile);
+	}
+	
+	// Populate timeArray and controlArray for each turbine
+	for (int i = 0; i < nTurbs; i++){
+		timeArray.push_back(tmpFloatVector);    // Populate with nTurbs vectors
+		controlArray.push_back(tmpFloatMatrix); // Populate with nTurbs matrices
+	}
+	
+	//Read the tables until the file end is found 
+	printf("SSC: Reading the input file line by line...\n");
+	fgets(buffer,500,fp); //Advance past the first comment line
+	for (int i = 0; 1 > 0; i++)
+	{
+		if(fscanf (fp, "%f", &temp) < 1)
+			break;
+		controlTime = temp; // First entry should be the simulation time (s)
+		
+		fscanf (fp, "%f", &temp);
+		turbID = temp; // Second entry should be the turbine number
+		
+		// Check if turbID exceeds number of turbines defined
+		if (turbID > nTurbs-1) {
+			printf("SSC: ERROR. You have defined control inputs for undefined turbines (turbine[%d]). Ignoring this row of inputs.\n",turbID);
+			for (int cVar = 0; cVar < nControlVars; cVar++) {
+				fscanf (fp, "%f", &temp);
+			}			
+		} 
+		else {
+			// Process control settings for this row of text
+			timeArray[turbID].push_back(controlTime); 		// Append with controlTime
+			printf("  Turbine[%d], time: %f \n", turbID,timeArray[turbID][nTurbInputs[turbID]]);
+			for (int cVar = 0; cVar < nControlVars; cVar++) {
+				fscanf (fp, "%f", &temp);
+				tmpControlVector[cVar] = temp;
+				printf("    Control setting [%d]: %f \n", cVar,tmpControlVector[cVar]);
+			}
+			controlArray[turbID].push_back(tmpControlVector); // Append control vector to controlArray
+			nTurbInputs[turbID] = nTurbInputs[turbID]+1; // Add one to the nTurbInputs
+		}
+
+	}
+	printf("Closing file...\n\n");
+	fclose(fp);	 //Close the file
+}
+
+// Function to determine next control setting
+void lookupControlAction(float simTime, int nTurbs, int nControlVars, std::vector< std::vector<float> >&timeArray, 
+							std::vector< std::vector <std::vector<float> > > &controlArray, std::vector<int> &nTurbInputs, 
+							std::vector< std::vector<float> >&nextControlAction)
+{
+	int controlIndex=0;
+	int controlSettingAvailable=0;
+	
+	// Determine next control setting for each turbine
+	for (int i = 0; i < nTurbs; i++){
+		controlSettingAvailable=0;
+		
+		// Find most recent timestamp of control settings for turbine i
+		for (int j = 0; j < nTurbInputs[i]; j++){
+			if(simTime >= timeArray[i][j]){
+				controlIndex = j; 
+				controlSettingAvailable=1;
+			}			
+		}
+		
+		// Write control settings of most recent time instant to outputs for turbine i
+		if (controlSettingAvailable == 1){
+			for (int cVar = 0; cVar < nControlVars; cVar++){
+				nextControlAction[i][cVar] = controlArray[i][controlIndex][cVar];
+			}
+		} else {
+			printf("SSC: WARNING: NO INITIAL CONDITIONS DEFINED FOR TURBINE %d. ASSUMING ZEROS.\n", i);
+			for (int cVar = 0; cVar < nControlVars; cVar++){
+				nextControlAction[i][cVar] = 0.0;
+			}			
+		}
+	}
+}
+
+void SC_timeTable(int nTurbs,int nControlVars, std::vector< std::vector<float> >&nextControlAction, float simTime)
+{
+	char *inputFile = "SC_INPUT.txt"; // Filename of input file/path address relative to main case folder
+		
+	static int isFirstCall = 1;
+	static std::vector<int> nTurbInputs(nTurbs, 0); 	 // Vector with number of input timestaps for each turbine
+	static std::vector< std::vector<float> > timeArray;  // Matrix with timestamps for each turbine
+	static std::vector< std::vector< std::vector<float> > > controlArray; // Tensor (3D matrix) with control settings for each turbine at each timestamp
+			
+	// Read input SSC file if first time this function is called
+	if(isFirstCall == 1){
+		readInputSSC(inputFile, nTurbs, nControlVars, nTurbInputs, timeArray, controlArray);
+		isFirstCall = 0; // disable for future calls
+	}
+	
+	// Retrieve control settings for time instant 'simTime'
+	lookupControlAction(simTime, nTurbs, nControlVars, timeArray,controlArray, nTurbInputs,nextControlAction);
+	
+	/*
+	// Print calculated control settings
+	for(int i=0; i < nTurbs; i++){
+		for(int j=0; j<nControlVars;j++){
+			printf("SSC: Turbine[%d], Updating control variables. Setpoint[%d]: %f.\n",i,j,nextControlAction[i][j]);
+		}
+	}*/
+}
+
+
+/*
+// Example function for stand-alone development & debugging
+int main()
+{
+	// Define integers and arrays
+	float simTime;
+	int nTurbs = 5;
+	int nOutputsFromSC = 2;
+	int nControlVars = nOutputsFromSC;
+	std::vector<float> tmpFloatVector(nControlVars, 0); 	 // Vector with number of input timestaps for each turbine
+	std::vector< std::vector<float> > nextControlAction(nTurbs,std::vector<float>(nOutputsFromSC)); // Matrix with current control actions for each turbine
+	
+	printf("TIME = 5.0 SECONDS.\n");
+	simTime = 5.0;
+	SC_timeTable(nTurbs,nOutputsFromSC,nextControlAction,simTime);
+
+	printf("TIME = 11 SECONDS.\n");
+	simTime = 11.0;
+	SC_timeTable(nTurbs,nOutputsFromSC,nextControlAction,simTime);
+
+	printf("TIME = 15 SECONDS.\n");
+	simTime = 15.0;	
+	SC_timeTable(nTurbs,nOutputsFromSC,nextControlAction,simTime);
+
+	printf("TIME = 21 SECONDS.\n");
+	simTime = 21.0;	
+	SC_timeTable(nTurbs,nOutputsFromSC,nextControlAction,simTime);
+	
+    return 0;
+}*/

--- a/src/turbineModels/turbineModelsStandard/horizontalAxisWindTurbinesADM/controllers/superControllers/timeTableSSC.H
+++ b/src/turbineModels/turbineModelsStandard/horizontalAxisWindTurbinesADM/controllers/superControllers/timeTableSSC.H
@@ -1,0 +1,27 @@
+//_SSC_
+
+// Define variables: Matrix with current control actions for each turbine
+std::vector< std::vector<float> > nextControlAction(numTurbines,std::vector<float>(nOutputsFromSC)); 
+
+// Call the SC from external library
+SC_timeTable(numTurbines,nOutputsFromSC,nextControlAction,runTime_.value());
+
+// Print the applied control settings
+for(int i=0; i < numTurbines; i++){
+	for(int j=0; j<nOutputsFromSC;j++){
+		printf("SSC: Turbine[%d], Updating control variables. Setpoint[%d]: %f.\n",i,j,nextControlAction[i][j]);
+	}
+}
+	
+// Format the SSC outputs to the appropriate dimensions and units
+for(int i = 0; i < numTurbines; i++)
+{
+	// In this example, the first entries are the yaw angles
+	superInfoFromSSC[i*nOutputsFromSC] = nextControlAction[i][0]; // Extract from the SSC output
+    superInfoFromSSC[i*nOutputsFromSC] = compassToStandard(superInfoFromSSC[i*nOutputsFromSC]); // Rotate
+    superInfoFromSSC[i*nOutputsFromSC] = superInfoFromSSC[i*nOutputsFromSC] * degRad; // Degrees to radians
+	
+	// In this example, the second entries are the min. blade pitch angles
+    superInfoFromSSC[i*nOutputsFromSC+1] = nextControlAction[i][1]; // Extract from the SSC output
+    superInfoFromSSC[i*nOutputsFromSC+1] = superInfoFromSSC[i*nOutputsFromSC+1] * degRad; // Degrees to radians
+}

--- a/src/turbineModels/turbineModelsStandard/horizontalAxisWindTurbinesADM/horizontalAxisWindTurbinesADM.C
+++ b/src/turbineModels/turbineModelsStandard/horizontalAxisWindTurbinesADM/horizontalAxisWindTurbinesADM.C
@@ -36,6 +36,7 @@ License
 #include "horizontalAxisWindTurbinesADM.H"
 #include "interpolateXY.H"
 #include "controllers/superControllers/SCSimple.C" //_SSC_ inclusion
+#include "controllers/superControllers/timeTableSSC.C" //_SSC_ inclusion
 
 namespace Foam
 {
@@ -1110,6 +1111,11 @@ void horizontalAxisWindTurbinesADM::callSuperController()
         {
         	#include "controllers/superControllers/SCSimple.H"
         }
+		
+        if (sscControllerType == "timeTableSSC")
+        {
+        	#include "controllers/superControllers/timeTableSSC.H"
+        }		
 }
 
 


### PR DESCRIPTION
The idea of this implementation is to have a more modular and more generic implementation. I tried to tackle a number of things:
- No predefined size of arrays, and no arrays larger than they have to be.
- No longer specific for yaw and blade pitch angles. Can take any number of inputs, as long as it is specified correctly in nOutputsFromSC and in the individual turbine controllers ("YawSC.H" and "PIDSC.H").
- Will give warnings to the log file when: 1) the input file is not found. 2) control inputs are defined for turbines that do not exist. 3) no initial control setting for the turbines is given.
- Make things a little more modular. Separate function for loading the data, separate function for determining next control inputs. This also limits the variables in the workspace.

This has a low priority for now, but nice to add eventually. Needs testing and decisions on what outputs/print statements are desired.