### PR TITLE
Bug fix for writing and collecting the measurements for the zeroMQ interface

### DIFF
--- a/src/turbineModels/turbineModelsStandard/horizontalAxisWindTurbinesADM/controllers/superControllers/zeromqSSC.C
+++ b/src/turbineModels/turbineModelsStandard/horizontalAxisWindTurbinesADM/controllers/superControllers/zeromqSSC.C
@@ -37,19 +37,18 @@ void SC_zeromq(float timeStep, std::vector<float> infoToSC, std::vector<float> &
 	  ssToSC << " " << infoToSC[i];
 	}
 	strToSSC = ssToSC.str();
-	std::cout << "infoToSC: " << strToSSC << "\n";
+	std::cout << "infoToSC: [" << strToSSC << "] \n";
 	
 	// Send and receive from SSC through zeroMQ
 	zmq_send (requester, strToSSC.c_str(), 9900, 0);
     zmq_recv (requester, charFromSSC, 9900, 0);
 	
 	// Format received char/string to std::vector
-	std::cout << "Received string: [" << charFromSSC << "].\n";
-    std::cout << "Reformatting string into std::vector...\n";
+	std::cout << "infoFromSC: [" << charFromSSC << "] \n";
 	std::stringstream ss(charFromSSC);
 	for(int i=0;i<sizeInfoFromSSC;i++){
 	  ss >> infoFromSC[i];
-	  printf("infoFromSC[%d] = %f \n",i,infoFromSC[i]);
+	  //printf("infoFromSC[%d] = %f \n",i,infoFromSC[i]);
 	}
 }
 

--- a/src/turbineModels/turbineModelsStandard/horizontalAxisWindTurbinesADM/controllers/yawControllers/yawSC.H
+++ b/src/turbineModels/turbineModelsStandard/horizontalAxisWindTurbinesADM/controllers/yawControllers/yawSC.H
@@ -26,10 +26,16 @@ else if  (yawError < 0)
 else
 	deltaNacYaw[i] = Foam::constant::mathematical::pi / 180.0 * runTime_.deltaT().value();  // Yaw positive
 
-// Write measurements for the superController
-for(int i = 0; i < numTurbines; i++){
-	// In our example case, we have nInputsToSSC = 3
+// Write measurements for the superController. In our example case, we have nInputsToSSC = 3
+if (Pstream::master()) {
+	// Only write for 1 core to avoid the output being InfoToSSC*nCores
 	superInfoToSSC[i*nInputsToSSC+0] = powerGenerator[i]; // Generator power
 	superInfoToSSC[i*nInputsToSSC+1] = torqueRotor[i];    // Turbine rotor torque
 	superInfoToSSC[i*nInputsToSSC+2] = thrust[i];         // Turbine thrust force
-}
+	} else {
+		// Important to set values to zero for other processors (!)
+		superInfoToSSC[i*nInputsToSSC+0] = 0.0;
+		superInfoToSSC[i*nInputsToSSC+1] = 0.0;
+		superInfoToSSC[i*nInputsToSSC+2] = 0.0;
+	}
+//}


### PR DESCRIPTION
Currently, the measurements were written for every core, and then summed at the end. This leads to the measuement vector being nCores times larger than it is supposed to be. This is corrected for. Furthermore, some debugging print statements are ommitted for a cleaner output log.